### PR TITLE
Can change campaign from new observation screen

### DIFF
--- a/src/components/NewObservationForm.tsx
+++ b/src/components/NewObservationForm.tsx
@@ -10,11 +10,11 @@ import {
   submitNewObservation,
 } from "../store/slices/observations";
 import { NewFeaturePayload } from "../store/slices/features";
-import { Geometry } from "../models";
+import { Campaign, Geometry } from "../models";
 import { useSelector } from "react-redux";
 import { Ionicons } from "@expo/vector-icons";
 import { NavigationProps } from "../navigation/types";
-import { ListItem, Text } from "./elements";
+import { ListItem, SectionHeader, Text } from "./elements";
 import { theme } from "../theme";
 
 interface InitialFormValuesShape {
@@ -58,6 +58,10 @@ function getGeometryFromFeatures(features: Array<NewFeaturePayload>): Geometry {
 const NewObservationForm = ({ navigation }: NavigationProps) => {
   const dispatch = useThunkDispatch();
 
+  const selectedCampaignEntry = useSelector<RootState, Campaign | undefined>(
+    (state) => state.campaigns.selectedCampaignEntry
+  );
+
   const featuresToAdd = useSelector<RootState, Array<NewFeaturePayload>>(
     (state) => state.features.featuresToAdd
   );
@@ -81,6 +85,22 @@ const NewObservationForm = ({ navigation }: NavigationProps) => {
     >
       {({ handleBlur, handleChange, handleSubmit, values }) => (
         <>
+          <SectionHeader>SELECTED CAMPAIGN</SectionHeader>
+          <ListItem
+              onPress={() => navigation.navigate("changeCampaignScreen")}
+            >
+            <Text
+                style={{
+                  color: theme.color.palette.gray,
+                  paddingVertical: theme.spacing.small,
+                }}
+              >
+                {selectedCampaignEntry
+                  ? selectedCampaignEntry.name
+                  : "Campaign-less observations"}
+            </Text>
+          </ListItem>
+
           <FormSection>
             <InputField
               invertColors={false}

--- a/src/navigation/tabs/AddNavigator.tsx
+++ b/src/navigation/tabs/AddNavigator.tsx
@@ -3,6 +3,7 @@ import { createStackNavigator } from "@react-navigation/stack";
 import NewObservationScreen from "../../screens/LoggedIn/Add/NewObservationScreen";
 import NewFeatureScreen from "../../screens/LoggedIn/Add/NewFeatureScreen";
 import FeatureTypePickerScreen from "../../screens/LoggedIn/Add/FeatureTypePickerScreen";
+import CampaignPickerScreen from "../../screens/LoggedIn/List/CampaignPickerScreen";
 
 const Stack = createStackNavigator();
 
@@ -23,6 +24,11 @@ export default function AddNavigator() {
         name="featureTypePickerScreen"
         component={FeatureTypePickerScreen}
         options={{ headerTitle: "Feature Type Picker" }}
+      />
+      <Stack.Screen
+        name="changeCampaignScreen"
+        component={CampaignPickerScreen}
+        options={{ headerTitle: "Change campaign" }}
       />
     </Stack.Navigator>
   );

--- a/src/store/slices/campaigns/actions.ts
+++ b/src/store/slices/campaigns/actions.ts
@@ -66,5 +66,5 @@ export const setSelectedCampaign: Thunk<{
   else if (campaignEntryPayload) dispatch(selectCampaign(campaignEntryPayload));
   dispatch(setObservationReachedPageEnd(false));
   dispatch(fetchObservations());
-  navigation.navigate("observationListScreen");
+  navigation.goBack();
 };


### PR DESCRIPTION
Pontus requested the possibility to see/change campaign from the new observation screen.
Added the campaign picker to the new observation view. Changed action so it redirects back instead to a specific view.

Designwise i'm not sure if it is okay or not..? Just copied the look of the other picker.