### PR TITLE
Rework new observation flow

### DIFF
--- a/src/components/NewObservationForm.tsx
+++ b/src/components/NewObservationForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { InputField } from "./InputField";
 import { Button, Image } from "react-native";
 import { Formik } from "formik";
@@ -40,6 +40,13 @@ const NewObservationForm = ({ navigation }: NavigationProps) => {
   const featuresToAdd = useSelector<RootState, Array<NewFeaturePayload>>(
     (state) => state.features.featuresToAdd
   );
+
+  useEffect(() => {
+    // If there are no features added to the obs., 
+    // go to new feature screen directly
+    if(featuresToAdd.length===0) 
+      navigation.navigate("newFeatureScreen")
+  }, [featuresToAdd])
 
   const handleFormSubmit = (values: any, actions: any) => {
     const newObservation: NewObservationPayload = {

--- a/src/navigation/tabs/AddNavigator.tsx
+++ b/src/navigation/tabs/AddNavigator.tsx
@@ -13,12 +13,12 @@ export default function AddNavigator() {
       <Stack.Screen
         name="newObservationScreen"
         component={NewObservationScreen}
-        options={{ headerTitle: "Add new observation" }}
+        options={{ headerTitle: "Submit observation" }}
       />
       <Stack.Screen
         name="newFeatureScreen"
         component={NewFeatureScreen}
-        options={{ headerTitle: "Add new feature" }}
+        options={{ headerTitle: "Add feature to observation" }}
       />
       <Stack.Screen
         name="featureTypePickerScreen"


### PR DESCRIPTION
Did a super-pragmatic solution for new create observation flow.

On add observation:

1. Check if observation has any added features, if not -> redirect to add feature view (will obviously happend on entry).
2. If user navigates back from add feature without adding one you will not end up in an infinite loop, because useEffect is only triggered if addedFeatures has been updated.. so here you can choose to add a feature, or do nothing.

Changed titles so they are more descriptive..

This was almost too simple of a solution but it seems to work fine, let me know if I haven't thought about something :D 